### PR TITLE
Add username verification

### DIFF
--- a/src/main/java/net/raphimc/viaproxy/cli/options/Options.java
+++ b/src/main/java/net/raphimc/viaproxy/cli/options/Options.java
@@ -46,6 +46,7 @@ public class Options {
     public static boolean ONLINE_MODE;
     public static boolean OPENAUTHMOD_AUTH;
     public static boolean BETACRAFT_AUTH;
+    public static boolean VERIFY_USERNAMES;
     public static Account MC_ACCOUNT;
     public static URI PROXY_URL; // Example: type://address:port or type://username:password@address:port
     public static boolean IGNORE_PACKET_TRANSLATION_ERRORS;
@@ -78,6 +79,7 @@ public class Options {
         final OptionSpec<VersionEnum> version = parser.acceptsAll(asList("version", "v"), "The version of the target server").withRequiredArg().withValuesConvertedBy(new VersionEnumConverter()).required();
         final OptionSpec<Void> openAuthModAuth = parser.acceptsAll(asList("openauthmod_auth", "oam_auth"), "Use OpenAuthMod for joining online mode servers");
         final OptionSpec<Integer> guiAccountIndex = parser.acceptsAll(asList("gui_account_index", "gui_account"), "Use an account from the ViaProxy GUI for joining online mode servers (Specify -1 for instructions)").withRequiredArg().ofType(Integer.class);
+        final OptionSpec<Void> verifyUsernames = parser.acceptsAll(asList("vu", "verify_username"), "Verify username against selected account before proxying");
         final OptionSpec<Void> betaCraftAuth = parser.accepts("betacraft_auth", "Use BetaCraft authentication for classic servers");
         final OptionSpec<String> resourcePackUrl = parser.acceptsAll(asList("resource_pack_url", "resource_pack", "rpu", "rp"), "URL of a resource pack which clients can optionally download").withRequiredArg().ofType(String.class);
         final OptionSpec<String> proxyUrl = parser.acceptsAll(asList("proxy_url", "proxy"), "URL of a SOCKS(4/5)/HTTP(S) proxy which will be used for backend TCP connections").withRequiredArg().ofType(String.class);
@@ -101,6 +103,7 @@ public class Options {
             SRV_MODE = options.has(srvMode);
             INTERNAL_SRV_MODE = options.has(iSrvMode);
             ONLINE_MODE = options.has(proxyOnlineMode);
+            VERIFY_USERNAMES = options.has(verifyUsernames);
             CONNECT_ADDRESS = options.valueOf(connectAddress);
             PROTOCOL_VERSION = options.valueOf(version);
             if (options.has(connectPort)) {

--- a/src/main/java/net/raphimc/viaproxy/proxy/external_interface/ExternalInterface.java
+++ b/src/main/java/net/raphimc/viaproxy/proxy/external_interface/ExternalInterface.java
@@ -56,9 +56,14 @@ public class ExternalInterface {
 
     public static void fillPlayerData(final ProxyConnection proxyConnection) {
         Logger.u_info("auth", proxyConnection.getC2P().remoteAddress(), proxyConnection.getGameProfile(), "Filling player data");
+        final Account account = proxyConnection.getUserOptions().account();
+        
+        if (account != null && Options.VERIFY_USERNAMES && !account.getName().equals(proxyConnection.getGameProfile().getName())) {
+            proxyConnection.kickClient("§cUsername mismatch! You are logging in as " + proxyConnection.getGameProfile().getName() + " but the selected account in the proxy is " + account.getName() + ".");
+        }
+
         try {
-            if (proxyConnection.getUserOptions().account() != null) {
-                final Account account = proxyConnection.getUserOptions().account();
+            if (account != null) {
                 ViaProxy.getSaveManager().accountsSave.ensureRefreshed(account);
 
                 proxyConnection.setGameProfile(account.getGameProfile());

--- a/src/main/java/net/raphimc/viaproxy/ui/impl/AdvancedTab.java
+++ b/src/main/java/net/raphimc/viaproxy/ui/impl/AdvancedTab.java
@@ -50,6 +50,7 @@ public class AdvancedTab extends AUITab {
     JCheckBox legacySkinLoading;
     JCheckBox chatSigning;
     JCheckBox ignorePacketTranslationErrors;
+    JCheckBox verifyUsernames;
     JButton viaVersionDumpButton;
     JButton uploadLogsButton;
 
@@ -115,6 +116,13 @@ public class AdvancedTab extends AUITab {
             this.ignorePacketTranslationErrors.setSelected(false);
             ViaProxy.getSaveManager().uiSave.loadCheckBox("ignore_packet_translation_errors", this.ignorePacketTranslationErrors);
             GBC.create(body).grid(0, gridy++).insets(BODY_BLOCK_PADDING, BORDER_PADDING, 0, 0).anchor(GridBagConstraints.NORTHWEST).add(this.ignorePacketTranslationErrors);
+        }
+        {
+            this.verifyUsernames = new JCheckBox(I18n.get("tab.advanced.verify_usernames.label"));
+            this.verifyUsernames.setToolTipText(I18n.get("tab.advanced.verify_usernames.tooltip"));
+            this.verifyUsernames.setSelected(false);
+            ViaProxy.getSaveManager().uiSave.loadCheckBox("verify_usernames", this.verifyUsernames);
+            GBC.create(body).grid(0, gridy++).insets(BODY_BLOCK_PADDING, BORDER_PADDING, 0, 0).anchor(GridBagConstraints.NORTHWEST).add(this.verifyUsernames);
         }
 
         parent.add(body, BorderLayout.NORTH);
@@ -199,6 +207,7 @@ public class AdvancedTab extends AUITab {
         save.put("legacy_skin_loading", String.valueOf(this.legacySkinLoading.isSelected()));
         save.put("chat_signing", String.valueOf(this.chatSigning.isSelected()));
         save.put("ignore_packet_translation_errors", String.valueOf(this.ignorePacketTranslationErrors.isSelected()));
+        save.put("verify_usernames", String.valueOf(this.verifyUsernames.isSelected()));
         ViaProxy.getSaveManager().save();
     }
 

--- a/src/main/java/net/raphimc/viaproxy/ui/impl/GeneralTab.java
+++ b/src/main/java/net/raphimc/viaproxy/ui/impl/GeneralTab.java
@@ -210,6 +210,7 @@ public class GeneralTab extends AUITab {
         ViaProxy.getUI().advancedTab.legacySkinLoading.setEnabled(state);
         ViaProxy.getUI().advancedTab.chatSigning.setEnabled(state);
         ViaProxy.getUI().advancedTab.ignorePacketTranslationErrors.setEnabled(state);
+        ViaProxy.getUI().advancedTab.verifyUsernames.setEnabled(state);
         if (state) this.serverVersion.getActionListeners()[0].actionPerformed(null);
     }
 
@@ -253,6 +254,7 @@ public class GeneralTab extends AUITab {
             final String proxyUrl = ViaProxy.getUI().advancedTab.proxy.getText().trim();
             final boolean chatSigning = ViaProxy.getUI().advancedTab.chatSigning.isSelected();
             final boolean ignorePacketTranslationErrors = ViaProxy.getUI().advancedTab.ignorePacketTranslationErrors.isSelected();
+            final boolean verifyUsernames = ViaProxy.getUI().advancedTab.verifyUsernames.isSelected();
 
             try {
                 try {
@@ -292,6 +294,7 @@ public class GeneralTab extends AUITab {
                     Options.OPENAUTHMOD_AUTH = authMethod == 2;
                     Options.CHAT_SIGNING = chatSigning;
                     Options.IGNORE_PACKET_TRANSLATION_ERRORS = ignorePacketTranslationErrors;
+                    Options.VERIFY_USERNAMES = verifyUsernames;
 
                     if (!proxyUrl.isEmpty()) {
                         try {

--- a/src/main/resources/assets/language/en_US.properties
+++ b/src/main/resources/assets/language/en_US.properties
@@ -53,6 +53,8 @@ tab.advanced.chat_signing.label=Chat signing
 tab.advanced.chat_signing.tooltip=Enables sending signed chat messages on >= 1.19 servers.
 tab.advanced.ignore_packet_translation_errors.label=Ignore packet translation errors
 tab.advanced.ignore_packet_translation_errors.tooltip=Enabling this will prevent getting disconnected from the server when a packet translation error occurs and instead only print the error in the console.\nThis may cause issues depending on the type of packet which failed to translate.
+tab.advanced.verify_usernames.label=Verify Username when Joining
+tab.advanced.verify_usernames.tooltip=Enabling this will prevent connections when the selected account and your client's account have different usernames.\nUsername Verification prevents joining servers with the wrong account by using the client's account as a safety measure.
 tab.advanced.create_viaversion_dump.label=Create ViaVersion dump
 tab.advanced.create_viaversion_dump.success=Copied ViaVersion dump link to clipboard.
 tab.advanced.upload_latest_log.label=Upload latest log file


### PR DESCRIPTION
I added an option to make sure the usernames of the client and the proxy match, because it would prevent me from joining a server when I think I have a different account logged in.

It has both a GUI toggle, and a CLI argument: `--vu` and `--verify_usernames`.

I added it in `ExternalInterface::fillPlayerData` because it seemed like the only place with access to both the client and the account profiles at the same time. I reorganized some of the existing code so it's checked before the try block because `ProxyConnection::kickClient` throws, but in this case it's not an error.

I recognize that there might be a problem if the user changes the username and the proxy account data is outdated, but at this point I don't know how I would fix it without duplicating the exception handling code just for `AccountSaveV3::ensureRefreshed`, although a very quick glance shows that it's the only method that throws.

The German and Simplified Chinese translations were left outdated because I don't know those languages.