### PR TITLE
Add URI-compliant syntax for wildcard-domain-handling

### DIFF
--- a/src/main/java/net/raphimc/viaproxy/protocoltranslator/viaproxy/ViaProxyConfig.java
+++ b/src/main/java/net/raphimc/viaproxy/protocoltranslator/viaproxy/ViaProxyConfig.java
@@ -168,7 +168,7 @@ public class ViaProxyConfig {
     @Description({
             "Allows clients to specify a target server and version using wildcard domains.",
             "none: No wildcard domain handling.",
-            "public: Public wildcard domain handling. Intended for usage by external clients. (Example: address_port_version.viaproxy.127.0.0.1.nip.io)",
+            "public: Public wildcard domain handling. Intended for usage by external clients. (Example: address.<address>.port.<port>.version.<version>.viaproxy.127.0.0.1.nip.io)",
             "internal: Internal wildcard domain handling. Intended for local usage by custom clients. (Example: original-handshake-address\\7address:port\\7version\\7classic-mppass)"
     })
     private WildcardDomainHandling wildcardDomainHandling = WildcardDomainHandling.NONE;

--- a/src/main/java/net/raphimc/viaproxy/protocoltranslator/viaproxy/ViaProxyConfig.java
+++ b/src/main/java/net/raphimc/viaproxy/protocoltranslator/viaproxy/ViaProxyConfig.java
@@ -168,7 +168,7 @@ public class ViaProxyConfig {
     @Description({
             "Allows clients to specify a target server and version using wildcard domains.",
             "none: No wildcard domain handling.",
-            "public: Public wildcard domain handling. Intended for usage by external clients. (Example: address.<address>.port.<port>.version.<version>.viaproxy.127.0.0.1.nip.io)",
+            "public: Public wildcard domain handling. Intended for usage by external clients. (Example: address.<address>.port.<port>.version.<version>.viaproxy.127.0.0.1.nip.io (version is optional))",
             "internal: Internal wildcard domain handling. Intended for local usage by custom clients. (Example: original-handshake-address\\7address:port\\7version\\7classic-mppass)"
     })
     private WildcardDomainHandling wildcardDomainHandling = WildcardDomainHandling.NONE;

--- a/src/main/java/net/raphimc/viaproxy/proxy/client2proxy/Client2ProxyHandler.java
+++ b/src/main/java/net/raphimc/viaproxy/proxy/client2proxy/Client2ProxyHandler.java
@@ -67,7 +67,7 @@ import java.util.regex.Pattern;
 public class Client2ProxyHandler extends SimpleChannelInboundHandler<Packet> {
 
     private static final Pattern ADDRESS_SYNTAX_PATTERN = Pattern.compile(
-            "^address\\.(.+?)\\.port\\.(\\d+?)\\.version\\.(.+?)$"
+            "^address\\.(.+?)\\.port\\.(\\d+?)(?:\\.version\\.(.+?))?$"
     );
 
     private ProxyConnection proxyConnection;
@@ -161,9 +161,14 @@ public class Client2ProxyHandler extends SimpleChannelInboundHandler<Packet> {
                     final int connectPort = Integer.parseInt(matcher.group(2));
                     final String versionString = matcher.group(3);
 
-                    serverVersion = ProtocolVersionUtil.fromNameLenient(versionString);
-                    if (serverVersion == null) {
-                        this.proxyConnection.kickClient("§cWrong domain syntax!\n§cUnknown server version.");
+                    if (versionString != null) {
+                        serverVersion = ProtocolVersionUtil.fromNameLenient(versionString);
+                        if (serverVersion == null) {
+                            this.proxyConnection.kickClient("§cWrong domain syntax!\n§cUnknown server version.");
+                        }
+                    } else {
+                        // When no version is specified, use the auto-detect protocol
+                        serverVersion = ProtocolTranslator.AUTO_DETECT_PROTOCOL;
                     }
 
                     serverAddress = AddressUtil.parse(connectAddress + ":" + connectPort, serverVersion);


### PR DESCRIPTION
This PR introduces an additional address syntax for `wildcard-domain-handling: PUBLIC`:

- Original syntax: `<ip>_<port>_<version>.viaproxy.hostname`
- New syntax: `address.<ip>.port.<port>.version.<version>.viaproxy.hostname`

## Why Add This Syntax?
1. **URI Compliance:** The original syntax using underscores (`_`) is not URI-compliant. This causes errors when attempting to use these addresses in BungeeCord's `config.yml`.
2. **Improved Readability:** The new syntax is more descriptive and easier to understand.

## Additional Feature
- The `.version.<backend-version>` section is now optional.  
If omitted, the version will be auto-detected.

## Related Project
To address compatibility issues with BungeeCord, I developed a BungeeCord plugin called **BungeeViaProxy**:  
[https://github.com/Kamesuta/BungeeViaProxy](https://github.com/Kamesuta/BungeeViaProxy)

This plugin resolves key issues, such as:
- Correctly forwarding the hostname specified in BungeeCord's config.
- Preventing duplicate server errors when multiple `.viaproxy.` addresses resolve to the same backend IP.

If helpful, I’d be happy to transfer ownership of this plugin to the [ViaVersionAddons](https://github.com/ViaVersionAddons) organization for continued maintenance.