### PR TITLE
fix: authentication request through proxy

### DIFF
--- a/src/main/java/net/raphimc/viaproxy/proxy/external_interface/AuthLibServices.java
+++ b/src/main/java/net/raphimc/viaproxy/proxy/external_interface/AuthLibServices.java
@@ -29,4 +29,12 @@ public class AuthLibServices {
     public static final MinecraftSessionService SESSION_SERVICE = AUTHENTICATION_SERVICE.createMinecraftSessionService();
     public static final GameProfileRepository PROFILE_REPOSITORY = AUTHENTICATION_SERVICE.createProfileRepository();
 
+    public static MinecraftSessionService getSessionService(final Proxy proxy) {
+        if (proxy == null || proxy == Proxy.NO_PROXY) {
+            return SESSION_SERVICE;
+        }
+
+        return new YggdrasilAuthenticationService(proxy).createMinecraftSessionService();
+    }
+
 }


### PR DESCRIPTION
ViaProxy is not authenticating through the defined Proxy URL which causes the following error: 'Not authenticated with Minecraft.net'

Currently as draft because it contains duplicated code. This was a quick fix for a customer of LiquidProxy.

![image](https://github.com/user-attachments/assets/e4b2b647-92ee-4801-a696-02434f6c8032)
