### PR TITLE
Add QEMU & arm64 build to build-docker.yml

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,6 +26,8 @@ jobs:
           check-latest: true
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}
@@ -47,6 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Would allow for ViaProxy to be run in a container on ARM devices (such as the Raspberry Pi)