### PR TITLE
Fix potential NPE when serverVersion is null in ViaProxyVersionProvider

### DIFF
--- a/src/main/java/net/raphimc/viaproxy/protocoltranslator/providers/ViaProxyVersionProvider.java
+++ b/src/main/java/net/raphimc/viaproxy/protocoltranslator/providers/ViaProxyVersionProvider.java
@@ -46,7 +46,11 @@ public class ViaProxyVersionProvider extends BaseVersionProvider {
             if (serverVersion != null) {
                 return serverVersion;
             }
-            return super.getClosestServerProtocol(connection);
+            try {
+                return super.getClosestServerProtocol(connection);
+            } catch (Exception e) {
+                return ProtocolVersion.unknown;
+            }
         } else if (clientProtocol.getVersionType() == VersionType.RELEASE) {
             if (MCVersion.ALL_VERSIONS.containsKey(clientProtocol.getVersion())) {
                 return clientProtocol;


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs downstream in ViaVersion when `ViaProxyVersionProvider#getClosestServerProtocol` returns `null` for client-side connections. The returned `null` propagates into ViaVersion logic where `serverVersion.equals(...)` is called, producing:
```
NullPointerException: Cannot invoke "com.viaversion.viaversion.api.protocol.version.ProtocolVersion.equals(Object)" because "serverVersion" is null
```