### PR TITLE
Update docker's JDK to 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app/run
 COPY /build/libs/ViaProxy-*.jar /app/ViaProxy.jar
 ENTRYPOINT ["java", "-jar", "/app/ViaProxy.jar", "config", "viaproxy.yml"]


### PR DESCRIPTION
Title says it all, This also makes the JDK version consistent with the one set in [GitHub Actions script](https://github.com/ViaVersion/ViaProxy/blob/c17b673d77cfc41d05bc2719c79dcb0aaa981938/.github/workflows/build-docker.yml#L25).